### PR TITLE
不要なToArrayとList変数を削除し遅延評価ができるように

### DIFF
--- a/Editor/Rules/ControllerLayerWeightRule.cs
+++ b/Editor/Rules/ControllerLayerWeightRule.cs
@@ -20,14 +20,11 @@ namespace VRCAvatars3Validator.Rules
         public override IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar)
         {
             var controllers = avatar.baseAnimationLayers
-                                .Select(l => l.animatorController);
-
-            if (!controllers.Any()) yield break;
+                                .Select(l => l.animatorController as AnimatorController)
+                                .Where(c => c != null);
 
             foreach (AnimatorController controller in controllers)
             {
-                if (controller is null) continue;
-
                 // 一番上のLayerは内部的にweight0であっても強制的に1になるので調べない
                 for (int i = 1; i < controller.layers.Length; i++)
                 {

--- a/Editor/Rules/ControllerLayerWeightRule.cs
+++ b/Editor/Rules/ControllerLayerWeightRule.cs
@@ -19,14 +19,11 @@ namespace VRCAvatars3Validator.Rules
 
         public override IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar)
         {
-            var controllers =  avatar.baseAnimationLayers
-                                .Select(l => l.animatorController)
-                                .Where(c => c != null)
-                                .ToArray();
+            var controllers = avatar.baseAnimationLayers
+                                .Select(l => l.animatorController);
 
-            if (!controllers.Any()) return Array.Empty<ValidateResult>();
+            if (!controllers.Any()) yield break;
 
-            var errors = new List<ValidateResult>();
             foreach (AnimatorController controller in controllers)
             {
                 if (controller is null) continue;
@@ -37,15 +34,14 @@ namespace VRCAvatars3Validator.Rules
                     var layer = controller.layers[i];
                     if (layer.defaultWeight == 0)
                     {
-                        errors.Add(new ValidateResult(
+                        yield return new ValidateResult(
                                     Id,
                                     controller,
                                     ValidateResult.ValidateResultType.Warning,
-                                    $"{layer.name} Layer in {controller.name} is weight 0."));
+                                    $"{layer.name} Layer in {controller.name} is weight 0.");
                     }
                 }
             }
-            return errors;
         }
     }
 }

--- a/Editor/Rules/HaveExParamsInControllersRule.cs
+++ b/Editor/Rules/HaveExParamsInControllersRule.cs
@@ -22,15 +22,13 @@ namespace VRCAvatars3Validator.Rules
         {
             var exParamsAsset = avatar.expressionParameters;
 
-            if (exParamsAsset is null) return Array.Empty<ValidateResult>();
+            if (exParamsAsset is null) yield break;
 
             var exParams = exParamsAsset.parameters.Where(p => !string.IsNullOrEmpty(p.name)).ToArray();
 
-            if (!exParams.Any()) return Array.Empty<ValidateResult>();
+            if (!exParams.Any()) yield break;
 
-            var errors = new List<ValidateResult>();
-
-            var parameterlist = GetParameterList(avatar.baseAnimationLayers.Select(l => l.animatorController).Where(l => l != null).ToArray());
+            var parameterlist = GetParameters(avatar.baseAnimationLayers.Select(l => l.animatorController).Where(l => l != null).ToArray());
 
             bool found = false;
             foreach (var exParam in exParams)
@@ -51,28 +49,26 @@ namespace VRCAvatars3Validator.Rules
                 }
                 if (!found)
                 {
-                    errors.Add(new ValidateResult(
+                    yield return new ValidateResult(
                                 Id,
                                 exParamsAsset,
                                 ValidateResult.ValidateResultType.Error,
-                                $"{exParamName} is not found in AnimatorControllers"));
+                                $"{exParamName} is not found in AnimatorControllers");
                 }
             }
-
-            return errors;
         }
 
-        private AnimatorControllerParameter[] GetParameterList(IEnumerable<RuntimeAnimatorController> controllers)
+        private IEnumerable<AnimatorControllerParameter> GetParameters(IEnumerable<RuntimeAnimatorController> controllers)
         {
-            var parameterList = new List<AnimatorControllerParameter>();
             foreach (AnimatorController controller in controllers)
             {
                 if (controller is null) continue;
 
-                parameterList.AddRange(controller.parameters);
+                foreach (var parameter in controller.parameters)
+                {
+                    yield return parameter;
+                }
             }
-
-            return parameterList.ToArray();
         }
     }
 }

--- a/Editor/Rules/HaveTransformAnimationRule.cs
+++ b/Editor/Rules/HaveTransformAnimationRule.cs
@@ -27,9 +27,8 @@ namespace VRCAvatars3Validator.Rules
         {
             var playableLayers = avatar.baseAnimationLayers.Where(l => l.animatorController != null);
 
-            if (!playableLayers.Any()) return Array.Empty<ValidateResult>();
+            if (!playableLayers.Any()) yield break;
 
-            var errors = new List<ValidateResult>();
             foreach (var playableLayer in playableLayers)
             {
                 if (playableLayer.type == VRCAvatarDescriptor.AnimLayerType.FX) continue;
@@ -50,17 +49,15 @@ namespace VRCAvatars3Validator.Rules
                         if (binding.type != typeof(Transform) &&
                             !(binding.type == typeof(Animator) && humanoidBoneNames.Any(n => binding.propertyName.StartsWith(n))))
                         {
-                            errors.Add(new ValidateResult(
+                            yield return new ValidateResult(
                                 Id,
                                 clip,
                                 ValidateResult.ValidateResultType.Error,
-                                $"{clip.name} have key changed other than Transform"));
+                                $"{clip.name} have key changed other than Transform");
                         }
                     }
                 }
             }
-
-            return errors;
         }
 
         private string ToContainSpace(string input)

--- a/Editor/Rules/TestRule.cs
+++ b/Editor/Rules/TestRule.cs
@@ -25,8 +25,7 @@ namespace VRCAvatars3Validator.Rules
                             ValidateResult.ValidateResultType.Warning,
                             $"Test Error {i}",
                             "Press AutoFix",
-                            () => Debug.Log($"Test{i}")))
-                        .ToArray();
+                            () => Debug.Log($"Test{i}")));
         }
     }
 }


### PR DESCRIPTION
- 不要な`ToArray`の呼び出しをを削除
- List変数を使わず直接`yield return`するように変更