### PR TITLE
警告メッセージではアップロードを停止しないようにするToggleパラメータを追加

### DIFF
--- a/Assets/VRCAvatars3Validator/Editor/AvatarUploadWatcher.cs
+++ b/Assets/VRCAvatars3Validator/Editor/AvatarUploadWatcher.cs
@@ -15,6 +15,7 @@ using VRCSDKRequestedBuildType = VRCAvatars3Validator.Mocks.VRCSDKRequestedBuild
 using VRCAvatars3Validator.Models;
 using VRCAvatars3Validator.Utilities;
 using VRCAvatars3Validator.Views;
+using System.Collections.Generic;
 
 namespace VRCAvatars3Validator
 {
@@ -36,10 +37,8 @@ namespace VRCAvatars3Validator
 
             var resultDictionary = VRCAvatars3Validator.ValidateAvatars3(avatar, settings.rules);
 
-            if (resultDictionary
-                    .Any(result => result.Value.Any(
-                        r => r.ResultType == ValidateResult.ValidateResultType.Error ||
-                            r.ResultType == ValidateResult.ValidateResultType.Warning)))
+            if (IncludeErrorResult(resultDictionary) || 
+                (IncludeWarningResult(resultDictionary) && settings.suspendUploadingByWarningMessage))
             {
                 VRCAvatars3ValidatorView.Open();
                 return false;
@@ -47,5 +46,11 @@ namespace VRCAvatars3Validator
 
             return true;
         }
+
+        private bool IncludeErrorResult(Dictionary<int, IEnumerable<ValidateResult>> resultDictionary)
+            => resultDictionary.Any(result => result.Value.Any(r => r.ResultType == ValidateResult.ValidateResultType.Error));
+
+        private bool IncludeWarningResult(Dictionary<int, IEnumerable<ValidateResult>> resultDictionary)
+    => resultDictionary.Any(result => result.Value.Any(r => r.ResultType == ValidateResult.ValidateResultType.Warning));
     }
 }

--- a/Assets/VRCAvatars3Validator/Editor/Models/ValidatorSettings.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Models/ValidatorSettings.cs
@@ -10,6 +10,7 @@ namespace VRCAvatars3Validator.Models
     public class ValidatorSettings : ScriptableObject
     {
         public bool validateOnUploadAvatar = true;
+        public bool suspendUploadingByWarningMessage = true;
 
         public List<RuleItem> rules = new List<RuleItem>();
     }

--- a/Assets/VRCAvatars3Validator/Editor/Views/VRCAvatars3ValidatorSettingsProvider.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Views/VRCAvatars3ValidatorSettingsProvider.cs
@@ -23,6 +23,10 @@ namespace VRCAvatars3Validator.Views
 
                     EditorGUILayout.Space();
 
+                    settings.suspendUploadingByWarningMessage = EditorGUILayout.ToggleLeft("Suspend uploading by warning message", settings.suspendUploadingByWarningMessage);
+
+                    EditorGUILayout.Space();
+
                     EditorGUILayout.LabelField("Enable Rules", EditorStyles.boldLabel);
 
                     var ruleNames = settings.rules.Select(rule => rule.Name).ToArray();


### PR DESCRIPTION
# 解決したいこと
* アップロード時の自動テストではエラーメッセージや警告メッセージが出ればアップロードを停止していた
* アバターのギミックを組む上でありえる内容を示した警告メッセージでは停止しなくてもいいかもしれない

# やったこと
* 警告メッセージで停止するかを設定できるパラメータを追加
* このパラメータを設定ウィンドウから変更できるようにした