### PR TITLE
Validate関数が受け取る引数からValidatorSettingsを削除

### DIFF
--- a/Assets/VRCAV3ValidTest/Editor/Tests/ExpressionsSubMenuRuleTest.cs
+++ b/Assets/VRCAV3ValidTest/Editor/Tests/ExpressionsSubMenuRuleTest.cs
@@ -32,9 +32,7 @@ namespace VRCAvatars3Validator.Tests
                 new ValidateResult(vrcAvatarDescriptor.expressionsMenu.controls[2].subMenu.controls[1].subMenu, ValidateResult.ValidateResultType.Error, "`Unset Sub Menu 4` exists unset SubMenu."),
             };
 
-            var settings = ScriptableObject.CreateInstance<ValidatorSettings>();
-            settings.rules.Add(new RuleItem());
-            var results = new ExpressionsSubMenuRule().Validate(vrcAvatarDescriptor, settings, settings.rules[0].Options).ToArray();
+            var results = new ExpressionsSubMenuRule().Validate(vrcAvatarDescriptor, new RuleItemOptions()).ToArray();
 
             Assert.AreEqual(4, results.Length);
 

--- a/Assets/VRCAV3ValidTest/Editor/Tests/HaveNoMissingAnimationPathRuleTest.cs
+++ b/Assets/VRCAV3ValidTest/Editor/Tests/HaveNoMissingAnimationPathRuleTest.cs
@@ -31,9 +31,7 @@ namespace VRCAvatars3Validator.Tests
                 new ValidateResult(AssetDatabase.LoadAssetAtPath<AnimationClip>(AssetDatabase.GUIDToAssetPath("7a10dddcd1fb33c48b79d0eafe93949f")), ValidateResult.ValidateResultType.Warning, "`HaveMissing2` have missing path. (Parent/Capsules)"),
             };
 
-            var settings = ScriptableObject.CreateInstance<ValidatorSettings>();
-            settings.rules.Add(new RuleItem());
-            var results = new HaveNoMissingAnimationPathRule().Validate(vrcAvatarDescriptor, settings, settings.rules[0].Options).ToArray();
+            var results = new HaveNoMissingAnimationPathRule().Validate(vrcAvatarDescriptor, new RuleItemOptions()).ToArray();
 
             Assert.AreEqual(3, results.Length);
 

--- a/Assets/VRCAvatars3Validator/Editor/Interfaces/IRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Interfaces/IRule.cs
@@ -20,6 +20,6 @@ namespace VRCAvatars3Validator
         /// </summary>
         /// <param name="avatar">Validated avatar</param>
         /// <returns>Validate results</returns>
-        IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options);
+        IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options);
     }
 }

--- a/Assets/VRCAvatars3Validator/Editor/Rules/ControllerLayerWeightRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Rules/ControllerLayerWeightRule.cs
@@ -16,7 +16,7 @@ namespace VRCAvatars3Validator.Rules
     {
         public string RuleSummary => Localize.Translate("ControllerLayerWeightRule_summary");
 
-        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options)
+        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options)
         {
             var controllers = VRCAvatarUtility.GetControllers(avatar);
 

--- a/Assets/VRCAvatars3Validator/Editor/Rules/ExpressionsSubMenuRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Rules/ExpressionsSubMenuRule.cs
@@ -22,7 +22,7 @@ namespace VRCAvatars3Validator.Rules
     {
         public string RuleSummary => Localize.Translate("ExpressionsSubMenuRule_summary");
 
-        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options)
+        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options)
         {
             if (avatar.expressionsMenu is null) return Enumerable.Empty<ValidateResult>();
 

--- a/Assets/VRCAvatars3Validator/Editor/Rules/HaveExParamsInControllersRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Rules/HaveExParamsInControllersRule.cs
@@ -23,7 +23,7 @@ namespace VRCAvatars3Validator.Rules
     {
         public string RuleSummary => Localize.Translate("HaveExParamsInControllersRule_summary");
 
-        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options)
+        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options)
         {
             var exParamsAsset = VRCAvatarUtility.GetExpressionParametersAsset(avatar);
 

--- a/Assets/VRCAvatars3Validator/Editor/Rules/HaveNoMissingAnimationPathRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Rules/HaveNoMissingAnimationPathRule.cs
@@ -29,7 +29,7 @@ namespace VRCAvatars3Validator.Rules
             };
         }
         
-        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options)
+        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options)
         {
             var animationClips = VRCAvatarUtility.GetAnimationClips(avatar);
             var ignoreAnimationFileRegexs = (options.ReadOptions<HaveNoMissingAnimationPathRuleOptions>() ?? new HaveNoMissingAnimationPathRuleOptions()).IgnoreAnimationFileRegexs;

--- a/Assets/VRCAvatars3Validator/Editor/Rules/HaveTransformAnimationRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Rules/HaveTransformAnimationRule.cs
@@ -19,7 +19,7 @@ namespace VRCAvatars3Validator.Rules
     {
         public string RuleSummary => Localize.Translate("HaveTransformAnimationRule_summary");
 
-        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options)
+        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options)
         {
             var humanoidBoneNames = Enum.GetNames(typeof(HumanBodyBones))
                                         .SelectMany(n => new string[] { n, ToContainSpace(n) })

--- a/Assets/VRCAvatars3Validator/Editor/Rules/TemplateRule.cs
+++ b/Assets/VRCAvatars3Validator/Editor/Rules/TemplateRule.cs
@@ -15,7 +15,7 @@ namespace VRCAvatars3Validator.Rules
     {
         public string RuleSummary => "Write rule summary.";
 
-        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, ValidatorSettings settings, RuleItemOptions options)
+        public IEnumerable<ValidateResult> Validate(VRCAvatarDescriptor avatar, RuleItemOptions options)
         {
             // Write validation code.
             // Return validation result if have error.

--- a/Assets/VRCAvatars3Validator/Editor/UseCases/VRCAvatars3Validator.cs
+++ b/Assets/VRCAvatars3Validator/Editor/UseCases/VRCAvatars3Validator.cs
@@ -14,7 +14,6 @@ namespace VRCAvatars3Validator
     {
         public static Dictionary<int, IEnumerable<ValidateResult>> ValidateAvatars3(VRCAvatarDescriptor avatar, IEnumerable<RuleItem> rules)
         {
-            var settings = ValidatorSettingsUtility.GetOrCreateSettings();
             if (avatar == null)
                 return new Dictionary<int, IEnumerable<ValidateResult>>();
             return rules.Select((rule, index) => new { Rule = rule, Index = index})
@@ -22,7 +21,7 @@ namespace VRCAvatars3Validator
                 .Select(rulePair =>
                 {
                     var rule = RuleUtility.FilePath2IRule(rulePair.Rule.FilePath);
-                    var results = rule.Validate(avatar, settings, rulePair.Rule.Options);
+                    var results = rule.Validate(avatar, rulePair.Rule.Options);
                     return new KeyValuePair<int, IEnumerable<ValidateResult>>(rulePair.Index + 1, results);
                 })
                 .ToDictionary(resultPair => resultPair.Key, resultPair => resultPair.Value);


### PR DESCRIPTION
当初は全体設定であるValidatorSettingsに各ルール内の設定を追加していく予定だったが、各ルール内の設定はRuleItemOptionsで管理していくことになったので、とりあえずこれを削除した
将来的に全体設定を参照したいことがあるかもしれないが、そのときは再度どうするか検討する